### PR TITLE
Fix prior dump download command in README (0-byte file)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To pretrain your own nanoTabPFN, you need to first download a prior data dump fr
 cd nanoTabPFN
 
 # download data dump
-curl -L -H "User-Agent: Mozilla/5.0" -H "Referer: https://figshare.com/" -o 300k_150x5_2.h5 "https://figshare.com/ndownloader/files/58932628?private_link=63fc1ada93e42e388e63"
+curl -L -o 300k_150x5_2.h5 "https://ndownloader.figshare.com/files/58932628?private_link=63fc1ada93e42e388e63"
 
 python train.py
 ```


### PR DESCRIPTION
## Problem

The README's curl command for the prior data dump produces a 0-byte `300k_150x5_2.h5`. The `figshare.com/ndownloader/...` path now sits behind AWS WAF, which responds to curl with an empty HTTP 202 and `x-amzn-waf-action: challenge` — a JavaScript browser challenge curl can't execute. Since 202 is a success code, curl exits 0 and silently writes an empty file.

## Fix

Use figshare's dedicated download host, which is not WAF-fronted and 302s directly to the signed S3 URL:

    curl -L -o 300k_150x5_2.h5 "https://ndownloader.figshare.com/files/58932628?private_link=63fc1ada93e42e388e63"

Also drops the `User-Agent`/`Referer` headers — they don't get past the WAF on the old URL and aren't needed on the new one.

## Verification

- Old URL: HTTP 202, `x-amzn-waf-action: challenge`, 0 bytes
- New URL: HTTP 302 → signed S3 URL, `Content-Length: 1037842694` (~990 MB), `content-disposition: attachment;filename=300k_150x5_2.h5`

Note: WAF behavior is on figshare's side and could be regional or change over time — worth a quick re-check of the old URL on your end.