### PR TITLE
Save average plot figure in experiment notebook

### DIFF
--- a/experiment.ipynb
+++ b/experiment.ipynb
@@ -408,7 +408,8 @@
     "sns.set_style(\"ticks\")\n",
     "sns.set_context(\"notebook\")\n",
     "fig, ax = plt.subplots(figsize=(6,4.5), layout=\"constrained\")\n",
-    "plot_runs(ax, histories, metric, baselines)"
+    "plot_runs(ax, histories, metric, baselines)\n",
+    "fig.savefig(\"nanotabpfn_average.png\", dpi=300)"
    ]
   },
   {


### PR DESCRIPTION
The notebook's final cell already saves the per-dataset grid figure (`nanotabpfn_summary.png`, dpi=300), but the single-panel average plot in the cell before it is only displayed, never saved. This adds a matching `fig.savefig("nanotabpfn_average.png", dpi=300)` so that figure can be reproduced from the notebook as well.