### PR TITLE
Simplify loss extraction to loss.item()

### DIFF
--- a/train.py
+++ b/train.py
@@ -95,7 +95,7 @@ def train(model: NanoTabPFNModel, prior: DataLoader,
 
             loss = criterion(output, targets).mean()
             loss.backward()
-            total_loss = loss.cpu().detach().item()
+            total_loss = loss.item()
 
             torch.nn.utils.clip_grad_norm_(model.parameters(), 1.)
             optimizer.step()


### PR DESCRIPTION
## What

One-line cleanup in the training loop:

```diff
-            total_loss = loss.cpu().detach().item()
+            total_loss = loss.item()
```

## Why

`.item()` on a scalar tensor already does the whole job: it detaches from the autograd graph, copies from the device to host memory, and converts to a Python number — on any device. The explicit `.cpu()` and `.detach()` calls add nothing.

Behavior is identical — `total_loss` is the same Python float either way.